### PR TITLE
feat: Vale checks also CheDocs style

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -13,7 +13,9 @@ jobs:
         uses: errata-ai/vale-action@v1.4.0
         with:
           files: __onlyModified
-          styles: https://github.com/vale-at-red-hat/vale-at-red-hat/releases/latest/download/RedHat.zip
+          styles: | 
+            https://github.com/vale-at-red-hat/vale-at-red-hat/releases/latest/download/RedHat.zip
+            https://github.com/vale-at-red-hat/chedocs/releases/latest/download/CheDocs.zip
           config: https://raw.githubusercontent.com/vale-at-red-hat/vale-at-red-hat/master/.vale-for-github-action.ini
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The Vale checks using the GitHub action are using the CheDocs style published on https://github.com/Vale-at-Red-Hat/CheDocs/releases