### PR TITLE
chore: vale should run only on pull requests

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -9,7 +9,7 @@
 
 name: Linting with Vale
 on:
-  - pull_request_target
+  - push
 jobs:
   vale:
     runs-on: ubuntu-20.04

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,16 +1,24 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
 name: Linting with Vale
 on:
   - pull_request_target
-  - push
 jobs:
   vale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - name: Vale Linter
-        uses: errata-ai/vale-action@v1.4.0
+        uses: errata-ai/vale-action@v1.4.2
         with:
           files: __onlyModified
           styles: https://github.com/vale-at-red-hat/vale-at-red-hat/releases/latest/download/RedHat.zip


### PR DESCRIPTION
Also update actions/image to use fixed tags

pull_request_target does not work on forked repository