### PR TITLE
fix: using the 'next' tag in the docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Using docker or Podman:
 
 From the root directory of the repository:
 ```
-$ docker run --rm -it -p 4000:4000 -p 35729:35729 -v $(pwd):/projects quay.io/eclipse/che-blog jekyll serve --incremental --watch --host 0.0.0.0 --livereload --livereload-port 35729
+$ docker run --rm -it -p 4000:4000 -p 35729:35729 -v $(pwd):/projects quay.io/eclipse/che-blog:next jekyll serve --incremental --watch --host 0.0.0.0 --livereload --livereload-port 35729
 ```
 Content is available at http://localhost:4000
 


### PR DESCRIPTION
the latest tag does not exist https://quay.io/repository/eclipse/che-blog?tag=latest&tab=tags