### PR TITLE
chore: location for eclipse-che/che-docs-vale-style

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=vale-builder /vale/bin/vale /usr/local/bin/vale
 RUN mkdir -p /home/jekyll/.vale/styles
 WORKDIR /home/jekyll/.vale/styles
 RUN wget -qO- https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/RedHat.zip | unzip -
-RUN wget -qO-  https://github.com/redhat-documentation/chedocs/releases/latest/download/CheDocs.zip | unzip -
+RUN wget -qO-  https://github.com/eclipse-che/che-docs-vale-style/releases/latest/download/CheDocs.zip | unzip -
 COPY --chown=jekyll:jekyll .docker/.vale.ini /home/jekyll/.vale.ini
 COPY --chown=jekyll:jekyll Gemfile .
 COPY --chown=jekyll:jekyll Gemfile.lock .

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -54,7 +54,7 @@ jobs:
           files: '${{ env.CHANGED_FILES }}'
           styles: |
             https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/RedHat.zip
-            https://github.com/redhat-documentation/CheDocs/releases/latest/download/RedHat.zip
+            https://github.com/eclipse-che/che-docs-vale-style/releases/latest/download/RedHat.zip
           config: https://raw.githubusercontent.com/redhat-documentation/vale-at-red-hat/master/.vale-for-github-action.ini
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
New location: https://github.com/eclipse-che/che-docs-vale-style