### PR TITLE
fix: bump jekyll-feed to handle description field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "jekyll", "~> 4.2.1"
 gem "minima", "~> 2.5.1"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.15.1"
+  gem "jekyll-feed", "~> 0.16.0"
   gem "jekyll-asciidoc", "~> 3.0.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.4)
+    ffi (1.15.5)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
     i18n (1.8.11)
@@ -33,7 +33,7 @@ GEM
     jekyll-asciidoc (3.0.0)
       asciidoctor (>= 1.5.0)
       jekyll (>= 3.0.0)
-    jekyll-feed (0.15.1)
+    jekyll-feed (0.16.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
@@ -46,7 +46,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.7.0)
+    listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
@@ -61,7 +61,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (3.26.1)
+    rouge (3.27.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -78,9 +78,9 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.2.1)
   jekyll-asciidoc (~> 3.0.0)
-  jekyll-feed (~> 0.15.1)
+  jekyll-feed (~> 0.16.0)
   minima (~> 2.5.1)
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.7
+   2.2.24


### PR DESCRIPTION
https://github.com/jekyll/jekyll-feed/releases/tag/v0.16.0

As we already have description field, use it

```
Minor Enhancements
Add support for page.description in front matter to become entry <summary> (297)
```

Fixes https://github.com/eclipse/che/issues/21068