### PR TITLE
fix: do not explain warning about proposed API

### DIFF
--- a/_posts/2022-04-01-introducing-pair-programming.adoc
+++ b/_posts/2022-04-01-introducing-pair-programming.adoc
@@ -37,8 +37,6 @@ image::/assets/img/pair-programming-vscode/pair-programming-vscode.gif[Pair prog
 
 . Keep the defaults for all properties and click on the `start` button
 
-. Click "No" on "CodeTogether requires access to Visual Studio Code Proposed APIs"
-
 . A `Pair programming` link is then available in the clipboard.
 
 . You can share this link with your team members. They will be able to join your workspace.


### PR DESCRIPTION
It's gone since https://github.com/che-incubator/che-code/pull/38